### PR TITLE
aptではなくapt-getを使うように修正した。

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts
 
 WORKDIR /app
 
-RUN apt update && \
+RUN apt-get update && \
     npm install -g npm && \
     npm install -g @vue/cli && \
     npm install -g @vue/cli-service-global


### PR DESCRIPTION
# 対応内容
Dockerコンテナ構築時に下記のエラーが発生するため、aptではなくapt-getを使うように修正した。
```
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
```

# 参考記事
[エラー対処法：apt does not have a stable CLI interface. Use with caution in scripts.](https://prograshi.com/platform/docker/use-apt-get-in-dockerfile/)