### PR TITLE
3-5節 トランジション 第二項まで

### DIFF
--- a/Webデザインの現場で使える Vue.jsの教科書/chapter3/05_transition/sample_1.html
+++ b/Webデザインの現場で使える Vue.jsの教科書/chapter3/05_transition/sample_1.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"></script>
+    <style>
+        .fade-enter-active, .fade-leave-active {
+            transition: opacity 1s;
+        }
+        .fade-enter, .fade-leave-to {
+            opacity: 0;
+        }
+        .fade-enter-to, .fade-leave {
+            opacity: 1;
+        }
+    </style>
+</head>
+<body>
+<div id="app">
+    <h2>トランジション</h2>
+    <button @click="show = !show">
+        Toggle
+    </button>
+    <transition name="fade">
+        <p v-if="show">hello</p>
+    </transition>
+</div>
+<script>
+    new Vue({
+        el: '#app',
+        data: {
+            show: false,
+        },
+    })
+</script>
+</body>
+</html>

--- a/Webデザインの現場で使える Vue.jsの教科書/chapter3/05_transition/sample_2.html
+++ b/Webデザインの現場で使える Vue.jsの教科書/chapter3/05_transition/sample_2.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"></script>
+    <style>
+        .custom-duration {
+            transition: opacity 1s;
+        }
+
+        .custom-invisible {
+            opacity: 0;
+        }
+
+        .custom-visible {
+            opacity: 1;
+        }
+    </style>
+</head>
+<body>
+<div id="app">
+    <h2>カスタムクラスによるトランジション</h2>
+    <button @click="show = !show">
+        Toggle
+    </button>
+    <transition
+            name="custom-classes-transition"
+            enter-class="custom-invisible"
+            enter-active-class="custom-duration"
+            enter-to-class="custom-visible"
+            leave-class="custom-visible"
+            leave-active-class="custom-duration"
+            leave-to-class="custom-invisible"
+    >
+        <p v-if="show">hello</p>
+    </transition>
+</div>
+<script>
+    new Vue({
+        el: '#app',
+        data: {
+            show: false,
+        },
+    })
+</script>
+</body>
+</html>


### PR DESCRIPTION
# 内容
- transitionタグの確認
- カスタムクラスによるトランジション

# 所感
- transitionタグのnameがCSSのクラス属性名の接頭語と一致する、というのがなんとも直感的でなくて分かりにくい。PhpStormだと使用されていないクラス属性だと認識されてしまうのでやりづらい。
- カスタムクラスを指定するとき、enterだけ・leaveだけでも同じ動作をしたので両方指定している理由がよくわからなかった。開始から終了を一方指定すれば逆の変化もやってくれるのでは？