### PR TITLE
5-7節 タブ切り替え機能を実装した。

### DIFF
--- a/Webデザインの現場で使える Vue.jsの教科書/chapter5/07_switch_tab.html
+++ b/Webデザインの現場で使える Vue.jsの教科書/chapter5/07_switch_tab.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>タブ切り替え</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+    <link rel="stylesheet" href="https://cdn.rawgit.com/milligram/milligram/master/dist/milligram.min.css">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU"
+          crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.18.0/axios.min.js"></script>
+    <style>
+        .tab {
+            list-style: none;
+            border-bottom: 1px solid #ccc;
+        }
+        .tab-item {
+            border: 1px solid transparent;
+            border-bottom: none;
+            display: inline-block;
+            margin: 0 0 -1px;
+            border-radius: 4px 4px 0 0;
+        }
+        .tab-item:hover {
+            border-color: #ccc;
+        }
+        .tab-item a {
+            display: block;
+            padding: 10px 15px;
+        }
+        .tab-item.active {
+            border-color: #ccc;
+            background-color: #fff;
+        }
+        .tab-item.active a {
+            color: #606c76;
+        }
+    </style>
+</head>
+<body>
+<div id="app" class="container">
+    <h1>タブ</h1>
+    <ul class="tab">
+        <li class="tab-item" v-for="(item, index) in items" :key="index" :class="{ active: active === index }">
+            <a href="#" @click.prevent="activate(index)">{{ item.title }}</a>
+        </li>
+    </ul>
+    <div class="tab-content">
+        <div class="tab-pane" v-for="(item, index) in items" :key="index" v-show="active === index" v-html="item.text"></div>
+    </div>
+</div>
+<script>
+    const pageIdsApiUrl = 'https://ja.wikipedia.org/w/api.php?format=json&action=query&origin=*&list=random&rnnamespace=0&rnlimit=4'
+    const textApiUrl = 'https://ja.wikipedia.org/w/api.php?format=json&action=query&origin=*&prop=extracts&explaintext=1&exsectionformat=plain&exlimit=1'
+    new Vue({
+        el: '#app',
+        data() {
+            return {
+                items: [],
+                active: 0,
+            }
+        },
+        mounted() {
+            let pages = []
+            let pageIds = []
+            axios.get(pageIdsApiUrl).then((response) => {
+                pages = response.data.query.random
+
+                for (const page of pages) {
+                    pageIds.push(page.id)
+                }
+
+                for (const pageId of pageIds) {
+                    axios.get(textApiUrl + '&pageids=' + pageId).then((response) => {
+                        const page = response.data.query.pages[pageId]
+                        this.items.push({
+                            id: page.pageid,
+                            title: page.title,
+                            text: page.extract
+                        })
+                    })
+                }
+            })
+        },
+        methods: {
+            activate(index) {
+                this.active = index
+            }
+        },
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
# 対応内容
5-7節 タブ切り替え機能を実装した。

# 所感
- 登録不要のAPIを呼び出してタブに表示するためにいろいろ試行錯誤して3時間くらい潰した。世の中にはいろんなものがあるな・・・という勉強にはなった・・・かな。
タイトル・本文の形式でタブメニューにぴったりそうなのがWikipediaで、そこが沼の始まりだった。パラメータが多く、本文を一度に複数件取得するのはできないようになってるし、そういうAPI特有の仕様でいろいろ詰まった。記事を参考に、ランダムにID取得してさらにIDごとに本文をリクエストして表示・・という作りにしたのでタブが1つずつ表示されるという気持ち悪さがある。
本来ならタブクリック時に本文リクエストしたほうがよさそう。
- あと二節で終わりだ～～～！
- これ終わったらプログラミングに関して何の勉強進めようかな。AWS関連か、CODE COMPLETE再開するか・・・。

# 参考記事
- [【随時更新】一風変わったWeb APIをまとめてみた](https://qiita.com/danishi/items/42d8adf6291515e62284)
- [CORS header ‘Access-Control-Allow-Origin’ missing from Wikipedia API response [duplicate]](https://stackoverflow.com/questions/47733007/cors-header-access-control-allow-origin-missing-from-wikipedia-api-response)
- [WikipediaのAPIを使ってランダムに記事本文を取得する](https://asanonaoki.com/blog/wikipedia%e3%81%aeapi%e3%82%92%e4%bd%bf%e3%81%a3%e3%81%a6%e3%83%a9%e3%83%b3%e3%83%80%e3%83%a0%e3%81%ab%e8%a8%98%e4%ba%8b%e6%9c%ac%e6%96%87%e3%82%92%e5%8f%96%e5%be%97%e3%81%99%e3%82%8b/)
- [Wikipedia API Document](https://www.mediawiki.org/wiki/Extension:TextExtracts/ja)
- [Access Control Origin Header error using Axios](https://stackoverflow.com/questions/45975135/access-control-origin-header-error-using-axios)